### PR TITLE
Relocate cmake and pkgconfig files to an arch-independent path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,14 +197,14 @@ if(CLI11_INSTALL)
 
   # Make version available in the install
   install(FILES "${PROJECT_BINARY_DIR}/CLI11ConfigVersion.cmake"
-          DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/CLI11")
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/CLI11")
 
   # Install the export target as a file
   install(
     EXPORT CLI11Targets
     FILE CLI11Config.cmake
     NAMESPACE CLI11::
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/CLI11")
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/CLI11")
 
   # Use find_package on the installed package
   export(

--- a/cmake/CLI11GeneratePkgConfig.cmake
+++ b/cmake/CLI11GeneratePkgConfig.cmake
@@ -1,3 +1,3 @@
 configure_file("cmake/CLI11.pc.in" "CLI11.pc" @ONLY)
 
-install(FILES "${PROJECT_BINARY_DIR}/CLI11.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+install(FILES "${PROJECT_BINARY_DIR}/CLI11.pc" DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig")


### PR DESCRIPTION
When packaging the software for Debian, we found that `cmake` and `pkg-config` files are being installed under an arch-dependent path (`/usr/lib/<arch>`) using `CMAKE_INSTALL_LIBDIR`. Since the library is header only, we can install them in an arch-independent path using `CMAKE_INSTALL_DATADIR`.